### PR TITLE
Fix error describing docs, fix mistyped error codes, typographical adjustments

### DIFF
--- a/doc/man3/X509_STORE_CTX_get_error.pod
+++ b/doc/man3/X509_STORE_CTX_get_error.pod
@@ -228,6 +228,7 @@ The root CA is marked to reject the specified purpose.
 
 The current candidate issuer certificate was rejected because its subject name
 did not match the issuer name of the current certificate.
+Not used as of OpenSSL 1.1.0.
 
 =item B<X509_V_ERR_AKID_SKID_MISMATCH: authority and subject key identifier mismatch>
 

--- a/doc/man3/X509_STORE_CTX_get_error.pod
+++ b/doc/man3/X509_STORE_CTX_get_error.pod
@@ -135,7 +135,7 @@ The signature of the certificate is invalid.
 
 =item B<X509_V_ERR_CRL_SIGNATURE_FAILURE: CRL signature failure>
 
-The signature of the certificate is invalid.
+The signature of the CRL is invalid.
 
 =item B<X509_V_ERR_CERT_NOT_YET_VALID: certificate is not yet valid>
 

--- a/doc/man3/X509_STORE_CTX_get_error.pod
+++ b/doc/man3/X509_STORE_CTX_get_error.pod
@@ -412,11 +412,11 @@ Returned by the verify callback to indicate OCSP verification failed.
 Returned by the verify callback to indicate that the certificate is not
 recognized by the OCSP responder.
 
-=item B<X509_V_ERR_NO_ISSUER_PUBLIC_KEY, issuer certificate doesn't have a public key>
+=item B<X509_V_ERR_NO_ISSUER_PUBLIC_KEY: issuer certificate doesn't have a public key>
 
 The issuer certificate does not have a public key.
 
-=item B<X509_V_ERR_SIGNATURE_ALGORITHM_MISMATCH, Subject signature algorithm and issuer public key algorithm mismatch>
+=item B<X509_V_ERR_SIGNATURE_ALGORITHM_MISMATCH: Subject signature algorithm and issuer public key algorithm mismatch>
 
 The issuer's public key is not of the type required by the signature in
 the subject's certificate.

--- a/doc/man3/X509_STORE_CTX_get_error.pod
+++ b/doc/man3/X509_STORE_CTX_get_error.pod
@@ -375,11 +375,11 @@ This error is only possible in L<openssl-s_client(1)>.
 
 EE certificate key too weak.
 
-=item B<X509_ERR_CA_KEY_TOO_SMALL: CA certificate key too weak>
+=item B<X509_V_ERR_CA_KEY_TOO_SMALL: CA certificate key too weak>
 
 CA certificate key too weak.
 
-=item B<X509_ERR_CA_MD_TOO_WEAK: CA signature digest algorithm too weak>
+=item B<X509_V_ERR_CA_MD_TOO_WEAK: CA signature digest algorithm too weak>
 
 CA signature digest algorithm too weak.
 
@@ -412,11 +412,11 @@ Returned by the verify callback to indicate OCSP verification failed.
 Returned by the verify callback to indicate that the certificate is not
 recognized by the OCSP responder.
 
-=item B<509_V_ERROR_NO_ISSUER_PUBLI_KEY, issuer certificate doesn't have a public key>
+=item B<X509_V_ERR_NO_ISSUER_PUBLIC_KEY, issuer certificate doesn't have a public key>
 
 The issuer certificate does not have a public key.
 
-=item B<X509_V_ERROR_SIGNATURE_ALGORITHM_MISMATCH, Subject signature algorithm and issuer public key algorithm mismatch>
+=item B<X509_V_ERR_SIGNATURE_ALGORITHM_MISMATCH, Subject signature algorithm and issuer public key algorithm mismatch>
 
 The issuer's public key is not of the type required by the signature in
 the subject's certificate.


### PR DESCRIPTION
I fixed some wrong documentation and changed misspelled error codes.

beb60f6336 - Fix wrong docs for __X509_V_ERR_CRL_SIGNATURE_FAILURE__
 - The documentation for this error was identical with X509_V_ERR_CERT_SIGNATURE_FAILURE and didn't describe the error correctly.

16f83e3c66 - Add unused note to docs for __X509_V_ERR_SUBJECT_ISSUER_MISMATCH__
- In [verify.pod](https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/doc/man1/verify.pod) of version 1.1.1 docs is this error described as _Not used as of OpenSSL 1.1.0_, as are some other codes (e.g. __X509_V_ERR_AKID_SKID_MISMATCH__).
- Every other code marked as _Not used as of OpenSSL 1.1.0_ in the [verify.pod](https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/doc/man1/verify.pod) has a note about not being used anymore, so I added that note to this error as well.

06afa57e33 - Fix mistyped error codes
- Errors __X509_V_ERR_NO_ISSUER_PUBLIC_KEY__ and __X509_V_ERR_SIGNATURE_ALGORITHM_MISMATCH__ were firstly added to the code in [this commit](https://github.com/openssl/openssl/commit/ffd2df135a5d9f6d2627bd125f362298430fdc06) on 18 Dec 2018, then added to the documentation in [this big commit](https://github.com/openssl/openssl/commit/21d08b9ee9c0f7fabcad27b5d0b0c8c16f7dd1e9) on 12 Oct 2019, with misspelled error code names __509_V_ERROR_NO_ISSUER_PUBLI_KEY__ and __X509_V_ERROR_SIGNATURE_ALGORITHM_MISMATCH__.
- The other two codes (__X509_V_ERR_CA_KEY_TOO_SMALL__ and __X509_V_ERR_CA_MD_TOO_WEAK__) were added in [this commit](https://github.com/openssl/openssl/commit/fbb82a60dcbe820714a246ab3e7617eaf3a7b656) in 2016 but there is no documentation describing them added.
- In [the same big commit](https://github.com/openssl/openssl/commit/21d08b9ee9c0f7fabcad27b5d0b0c8c16f7dd1e9) were added two error codes(__X509_ERR_CA_KEY_TOO_SMALL__, __X509_ERR_CA_KEY_TOO_SMALL__) and these error codes are not found in the code.
- I changed the error codes in the documentation to the same ones that are in the code.

1deee30277 - Replace commas with colons in docs for consistency
- The last two errors had a comma right after the error code, every other error has a colon.


These small issues were found while doing research on better error documentation as discussed on the [openssl-project mailing list](https://mta.openssl.org/pipermail/openssl-project/2020-March/001882.html).